### PR TITLE
Simplify prefix

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,11 +1,12 @@
 const express           = require('express')
 const bodyParser        = require('body-parser')
-const { proxyPath } = require('./routes/utils');
 const ejs               = require('ejs')
 
 // Route links
 const redirectRoutes  = require('./routes/redirectRoutes')
 const rootRoutes    = require('./routes/rootRoutes')
+
+const PROXY_PATH_PREFIX = process.env.PROXY_PATH_PREFIX || '/';
 
 // Express
 const app = express()
@@ -13,17 +14,13 @@ const app = express()
 // App Config
 app.use(bodyParser.urlencoded({ extended: true }))
 
-// Tell monitoring system that application is up and running
-app.get(proxyPath('_monitor'), (req, res) => {
-  res.send("APPLICATION_STATUS: OK\n");
-})
-
-app.use(proxyPath(''), express.static(__dirname))
+app.use(PROXY_PATH_PREFIX, express.static(__dirname))
 app.set('view engine', 'ejs')
 
-// Use Routes
-app.use(redirectRoutes)
-app.use(rootRoutes)
+// Application specific route handlers
+app.use(PROXY_PATH_PREFIX, redirectRoutes)
+// General app route handlers
+app.use(PROXY_PATH_PREFIX, rootRoutes)
 
 // server is listening.....
 app.listen(process.env.PORT || 3000, function () {

--- a/routes/redirectRoutes.js
+++ b/routes/redirectRoutes.js
@@ -1,14 +1,8 @@
-const { proxyPath } = require('./utils');
 const express   = require('express')      
 const router    = express.Router({mergeParams: true});
 
-//index route
-router.get(proxyPath(''), function(req, res){
-  res.render('index');
-});
-
 //redirect route
-router.get(proxyPath('redirect'), function(req, res){
+router.get('/redirect', function(req, res){
   res.render('redirect', { redirectURL: 'https://canvas.kth.se/courses/'+req.query.cid });
 });
 

--- a/routes/rootRoutes.js
+++ b/routes/rootRoutes.js
@@ -1,22 +1,24 @@
-const { proxyPath } = require('./utils');
-
 const express = require('express')
 const router = express.Router({ mergeParams: true })
 
-router.get(proxyPath(''), function (req, res) {
+router.get('/', function (req, res) {
   res.render('index')
 })
 
+// Tell monitoring system that application is up and running
+router.get('/_monitor', (req, res) => {
+  res.send("APPLICATION_STATUS: OK\n");
+})
+
 // universal404
-router.get(proxyPath('404'), function (req, res) {
+router.get('/404', function (req, res) {
   res.render('fourOhFour')
 })
 
 // catchall for 404
 router.get('*', function (req, res) {
-  console.log('404ing, reason:')
-  console.log(req.params)
-  res.redirect(proxyPath('404'))
+  const PROXY_PATH_PREFIX = process.env.PROXY_PATH_PREFIX || '';
+  res.redirect(`${PROXY_PATH_PREFIX}/404`);
 })
 
 module.exports = router

--- a/routes/utils.js
+++ b/routes/utils.js
@@ -1,9 +1,0 @@
-const PROXY_PATH_PREFIX = process.env.PROXY_PATH_PREFIX || '/';
-
-module.exports.proxyPath = (enpointPath) => {
-    let sep="/";
-    if (PROXY_PATH_PREFIX.endsWith("/") || enpointPath.startsWith("/")) {
-        sep=""
-    }
-    return [PROXY_PATH_PREFIX, sep, enpointPath].join("");
-}


### PR DESCRIPTION
- move _monitor to rootRoutes.js
- remove prefixPath() and mount routers on PROXY_PREFIX_PATH instead
- remove utils.js (now unused)